### PR TITLE
Update heroku fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Imagine you want to run nginx in your `web` dynos, binding to `$PORT`, and front
 
 ## Usage
 
-You'll probably use this in conjunction with [the multi buildpack](https://github.com/ddollar/heroku-buildpack-multi).
+You'll probably use this in conjunction with [multiple buildpacks](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app).
 
 For every process type (eg `web`) you want to run mulitple processes in, add an entry like this to your `Procfile`:
 

--- a/bin/compile
+++ b/bin/compile
@@ -19,12 +19,12 @@ mkdir -p $SW_DIR
 install() {
   DEB_URL=$1
   DIR=$(mktemp -d)
-  curl -f $DEB_URL -o $DIR/deb
+  curl -Lf $DEB_URL -o $DIR/deb
   dpkg-deb -x $DIR/deb $SW_DIR
   rm -rf $DIR
 }
 
-install http://mirrors.kernel.org/ubuntu/pool/universe/r/runit/runit_2.1.1-6.2ubuntu3_amd64.deb
+install https://mirrors.edge.kernel.org/ubuntu/pool/universe/r/runit/runit_2.1.1-6.2ubuntu3_amd64.deb
 
 mkdir -p .profile.d
 cat > .profile.d/runit.sh <<EOF


### PR DESCRIPTION
The heroku fork of this buildpack is out of date and no longer functional. Updating it with the changes on the main repo will fix it. Not sure what the standard is here, but this being hosted on the heroku org feels "official", so long as this is here it should stay functional